### PR TITLE
Clarify API base URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ mvn spring-boot:run
 
 ## REST API (v1)
 
-* `POST /api/v1/parking/entry` – зарегистрировать въезд транспортного средства.
-* `POST /api/v1/parking/exit` – зарегистрировать выезд транспортного средства.
-* `GET  /api/v1/parking/report?start_date=...&end_date=...` – получить статистику по парковке за указанный период.
+Эндпоинты располагаются по адресу сервиса. При запуске локально сервис
+доступен на `http://localhost:8080`. Примеры запросов:
+
+* `POST http://localhost:8080/api/v1/parking/entry` – зарегистрировать
+  въезд транспортного средства.
+* `POST http://localhost:8080/api/v1/parking/exit` – зарегистрировать
+  выезд транспортного средства.
+* `GET  http://localhost:8080/api/v1/parking/report?start_date=...&end_date=...`
+  – получить статистику по парковке за указанный период.
 
 ## Конфигурация
 


### PR DESCRIPTION
## Summary
- document full address for REST endpoints in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6848804fafa883278d1633455aca5300